### PR TITLE
Add SCSS module typings

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.scss' {
+  const classes: { [key: string]: string };
+  export default classes;
+}


### PR DESCRIPTION
## Summary
- add global declaration for importing SCSS modules
- confirm tsconfig already includes `src/**/*`

## Testing
- `pnpm run lint` *(fails: ESLint couldn't find eslint-plugin-react)*
- `pnpm run format` *(fails: Prettier parse error in `public/js/main.js`)*
- `npx tsc --noEmit` *(fails: tsconfig option `suppressImplicitAnyIndexErrors` removed)*
- `pnpm run test` *(fails: Jest preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846b32f04bc832c9f12ab1b2e2bf7d2