### PR TITLE
Add MapViewState type for map hooks

### DIFF
--- a/src/hooks/useMapState.ts
+++ b/src/hooks/useMapState.ts
@@ -1,16 +1,16 @@
 import { useState, useCallback } from 'react';
-import { MapState } from '../types/map.types';
+import { MapViewState } from '../types/map.types';
 
 const DEFAULT_CENTER: { lat: number; lng: number } = { lat: 0, lng: 0 };
 const DEFAULT_ZOOM = 2;
 
 export const useMapState = () => {
-  const [mapState, setMapState] = useState<MapState>({
+  const [mapState, setMapState] = useState<MapViewState>({
     center: DEFAULT_CENTER,
     zoom: DEFAULT_ZOOM,
   });
 
-  const updateMapState = useCallback((newState: Partial<MapState>) => {
+  const updateMapState = useCallback((newState: Partial<MapViewState>) => {
     setMapState((prev) => ({
       ...prev,
       ...newState,

--- a/src/types/map.types.ts
+++ b/src/types/map.types.ts
@@ -16,6 +16,11 @@ export interface MapState {
   error: string | null;
 }
 
+export interface MapViewState {
+  center: Position;
+  zoom: number;
+}
+
 export interface MapBounds {
   north: number;
   south: number;


### PR DESCRIPTION
## Summary
- create `MapViewState` interface for map position
- use `MapViewState` in `useMapState` hook

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `npm test` *(fails: preset ts-jest not found)*
- `npm run build` *(fails: TS5102 option removed)*

------
https://chatgpt.com/codex/tasks/task_b_6846b3305dbc832ca9428e5129d04a17