### PR TITLE
Fix express error handler signature

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -23,12 +23,13 @@ app.use(express.urlencoded({ extended: true }));
 app.use(express.static('public'));
 
 // Error handling middleware
-app.use((err: Error, _req: express.Request, res: express.Response) => {
+app.use((err: Error, _req: express.Request, res: express.Response, next: express.NextFunction) => {
   console.error(err.stack);
   res.status(500).json({
     error: 'Something went wrong!',
     message: process.env.NODE_ENV === 'development' ? err.message : undefined,
   });
+  next();
 });
 
 // Serve index.html for all routes
@@ -37,7 +38,4 @@ app.get('*', (req, res) => {
 });
 
 // Start server
-app.listen(port, () => {
-  
-  
-});
+app.listen(port, () => {});


### PR DESCRIPTION
## Summary
- update Express error middleware signature in `server.ts`
- call `next()` after sending the error response

## Testing
- `pnpm lint` *(fails: 24 problems)*
- `pnpm test` *(fails to run tests)*
- `pnpm typecheck` *(script not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846bb66c904832ca59df12ab3a7821b