### PR TITLE
Fix map cleanup

### DIFF
--- a/src/__tests__/MapComponent.test.tsx
+++ b/src/__tests__/MapComponent.test.tsx
@@ -57,5 +57,11 @@ describe('MapComponent moveend handler', () => {
     expect(setMapState).toHaveBeenCalledWith({ center: { lat: 10, lng: 20 }, zoom: 5 });
 
     unmount();
+
+    const offCall = offMock.mock.calls.find(c => c[0] === 'moveend');
+    expect(offCall).toBeTruthy();
+    if (offCall) {
+      expect(offCall[1]).toBe(handler);
+    }
   });
 });

--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -41,20 +41,19 @@ export const MapComponent: React.FC<MapComponentProps> = ({
   useEffect(() => {
     if (!mapRef.current) return;
 
+    const mapInstance = mapRef.current;
+
     const moveHandler = () => {
-      if (!mapRef.current) return;
       setMapState({
-        center: mapRef.current.getCenter(),
-        zoom: mapRef.current.getZoom(),
+        center: mapInstance.getCenter(),
+        zoom: mapInstance.getZoom(),
       });
     };
 
-    mapRef.current.on('moveend', moveHandler);
+    mapInstance.on('moveend', moveHandler);
 
     return () => {
-      if (mapRef.current) {
-        const currentMapRef = mapRef.current;
-      }
+      mapInstance.off('moveend', moveHandler);
     };
   }, [setMapState]);
 


### PR DESCRIPTION
## Summary
- clean up map moveend listener with `.off`
- ensure `off` is called on unmount in MapComponent test

## Testing
- `pnpm test` *(fails: Cannot find module 'supertest'; DataExport CSV export > preserves 0 and false values when exporting CSV)*

------
https://chatgpt.com/codex/tasks/task_b_6846d9ff3ac4832c8fa7d865938b7aec