### PR TITLE
Update README install and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,31 @@ Use [pnpm](https://pnpm.io/) for dependency management:
 
 ```bash
 pnpm install
+```
+
+## 🏃‍♂️ Running Maptap
+
+Start the development server:
+
+```bash
+pnpm dev
+```
+
+Open <http://localhost:3000> in your browser to view the app.
+
+To build and run for production:
+
+```bash
+pnpm build
+pnpm start
+```
+
+## 🧪 Running Tests
+
+Run the test suite with:
+
+```bash
+pnpm test
+```
+
+Use `pnpm test:watch` while developing to re-run tests on file changes.


### PR DESCRIPTION
## Summary
- finish the installation block in the README
- document dev server, production build and test commands

## Testing
- `pnpm test` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_b_6846da045d88832ca7dc104ed4028f3b