### PR TITLE
Implement point selection for bulk editing

### DIFF
--- a/public/js/modals.js
+++ b/public/js/modals.js
@@ -146,6 +146,7 @@ export function applyBulkEdit() {
     selectedPoints.forEach(point => {
         if (status) point.status = status;
         if (group) point.group = group;
+        point.selected = false;
     });
 
     // Update UI

--- a/public/js/types.ts
+++ b/public/js/types.ts
@@ -10,6 +10,7 @@ export interface MapPoint {
     customFields?: Record<string, string>;
     createdAt: number;
     updatedAt: number;
+    selected?: boolean;
 }
 
 export type PointStatus = 'active' | 'pending' | 'completed' | 'delayed' | 'inactive';

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -235,6 +235,7 @@ export function updatePointsList() {
 
         container.innerHTML = currentPoints.map(point => `
             <div class="point-item" data-id="${point.id}">
+                <input type="checkbox" class="point-select" onchange="togglePointSelection('${point.id}', this.checked)" ${point.selected ? 'checked' : ''}>
                 <h4>${sanitizeInput(point.name)}</h4>
                 <p>Status: ${sanitizeInput(point.status)}</p>
                 ${point.group ? `<p>Group: ${sanitizeInput(point.group)}</p>` : ''}
@@ -261,6 +262,13 @@ export function updatePointsList() {
     } finally {
         const duration = performanceMonitor.end('updatePointsList');
         console.debug(`Points list updated in ${duration}ms`);
+    }
+}
+
+export function togglePointSelection(pointId, isSelected) {
+    const point = points.find(p => p.id === pointId);
+    if (point) {
+        point.selected = isSelected;
     }
 }
 


### PR DESCRIPTION
## Summary
- add optional `selected` field to `MapPoint`
- support toggling selections with checkboxes in the points list
- apply bulk edits only to selected points and reset selection

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_684efd005398832c9eac390de9b26801