### PR TITLE
Fix CSV header expectation

### DIFF
--- a/src/__tests__/DataExport.test.tsx
+++ b/src/__tests__/DataExport.test.tsx
@@ -51,7 +51,7 @@ describe('DataExport CSV export', () => {
       const csvContent = captured[0];
 
       // Verify CSV header and row values
-      expect(csvContent).toContain('id,lat,lng,zeroValue,falseValue');
+      expect(csvContent).toContain('id,latitude,longitude,zeroValue,falseValue');
       const dataRow = csvContent.trim().split('\n')[1];
       expect(dataRow).toBe('1,10,20,0,false');
     } finally {


### PR DESCRIPTION
## Summary
- update test to expect latitude/longitude headers

## Testing
- `pnpm lint` *(fails: ban-ts-comment, unused vars, etc.)*
- `pnpm test` *(fails: missing supertest module but DataExport.test.tsx passes)*

------
https://chatgpt.com/codex/tasks/task_b_684efd02afdc832ca9bc9b42ebcac08e