### PR TITLE
Fix README sections and add usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-````markdown
 # Maptap
 
 Enhanced Mobile Map CSV Editor for quickly editing and previewing geospatial data.
@@ -17,7 +16,7 @@ Use [pnpm](https://pnpm.io/) for dependency management:
 
 ```bash
 pnpm install
-````
+```
 
 ## 🧹 Linting
 
@@ -54,6 +53,36 @@ pnpm test
 
 Use `pnpm test:watch` while developing to re-run tests on file changes.
 
+
+## 📥 Importing and Exporting Data
+
+- Use the **Import** button to upload a CSV file. The map and table update automatically.
+- GeoJSON files can be imported through the same dialog.
+- Select **Export CSV** from the toolbar to download your current dataset.
+
+## 🗺️ Map Interaction
+
+- Click on the map to add a new point.
+- Drag existing markers to update their coordinates.
+
+## 🔌 Running the Backend Server
+
+Start the API server (useful for production builds):
+
+```bash
+pnpm start
 ```
+
+Set `PORT` in your environment to change the listening port.
+
+## ⚙️ Environment Configuration
+
+For optional Firebase integration, create a `.env` file with your Firebase credentials:
+
+```bash
+FIREBASE_API_KEY=your-api-key
+FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+FIREBASE_PROJECT_ID=your-project-id
 ```
-````
+
+These variables are loaded at runtime if present.


### PR DESCRIPTION
## Summary
- close dangling code fences in README
- add data import/export and map usage docs
- document backend start and Firebase env vars

## Testing
- `pnpm lint` *(fails: no-unused-vars and other eslint errors)*
- `pnpm test` *(fails: cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_b_684efd03dbec832ca27acd4f9546231f