### PR TITLE
Fix duplicate imports in ui-handlers

### DIFF
--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -1,15 +1,6 @@
-// UI event handlers and state management
 import { addMarker } from './map-init.js';
 import { debounce, sanitizeInput, Validator } from './utils.js';
-import {
-  points,
-  import { addMarker } from './map-init.js'; import { debounce, sanitizeInput, Validator } from './utils.js'; import { points, currentGroupFilter, pagination, undoRedoManager, performanceMonitor, setCurrentFilter } from './state.js';
-  currentGroupFilter,
-  pagination,
-  undoRedoManager,
-  performanceMonitor,
-  setCurrentFilter
-} from './state.js';
+import { points, currentGroupFilter, pagination, undoRedoManager, performanceMonitor, setCurrentFilter } from './state.js';
 
 
 // Initialize UI handlers


### PR DESCRIPTION
## Summary
- clean up duplicate imports in `ui-handlers.js`

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ban-ts-comment, no-unused-vars, no-explicit-any, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_685083aba1a8832cb6057180c775cef3