### PR TITLE
MP-4 add toast aria alert and tests

### DIFF
--- a/public/js/tests/file-io.test.js
+++ b/public/js/tests/file-io.test.js
@@ -1,0 +1,34 @@
+import { importFromCSV, importFromGeoJSON } from '../file-io.js';
+import { showToast } from '../ui-handlers.js';
+
+jest.mock('../ui-handlers.js', () => ({
+  showToast: jest.fn()
+}));
+
+describe('File IO error handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls showToast when CSV parsing fails', () => {
+    global.Papa = {
+      parse: (_file, options) => {
+        options.complete({ data: [], errors: [{ message: 'bad' }] });
+      }
+    };
+
+    const file = new File(['name,lat,lng\n'], 'points.csv', { type: 'text/csv' });
+    importFromCSV(file);
+    expect(showToast).toHaveBeenCalled();
+  });
+
+  it('calls showToast when GeoJSON parsing fails', (done) => {
+    const blob = new Blob(['invalid'], { type: 'application/json' });
+    const file = new File([blob], 'points.geojson', { type: 'application/json' });
+    importFromGeoJSON(file);
+    setTimeout(() => {
+      expect(showToast).toHaveBeenCalled();
+      done();
+    }, 0);
+  });
+});

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -303,6 +303,8 @@ export function filterPoints(status) {
 // Show toast message
 export function showToast(message, duration = 3000) {
     const toast = document.getElementById('toast');
+    if (!toast) return;
+    toast.setAttribute('role', 'alert');
     toast.textContent = message;
     toast.style.display = 'block';
 


### PR DESCRIPTION
## Summary
- enhance `showToast` with `role="alert"`
- test CSV & GeoJSON parse failure triggers toast

## Testing
- `pnpm lint` *(fails: no-unused-vars in src/utils/dataProcessing.ts)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_68563b058bd4832c8e5adad840a7114a