### PR TITLE
Update filter button toggle and tests

### DIFF
--- a/public/js/tests/ui-handlers.test.js
+++ b/public/js/tests/ui-handlers.test.js
@@ -116,6 +116,11 @@ describe('UI Handlers', () => {
 
             expect(activeBtn.classList.contains('active')).toBe(true);
             expect(allBtn.classList.contains('active')).toBe(false);
+
+            filterPoints('all');
+
+            expect(allBtn.classList.contains('active')).toBe(true);
+            expect(activeBtn.classList.contains('active')).toBe(false);
         });
     });
 

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -299,7 +299,7 @@ export function hidePointForm() {
 export function filterPoints(status) {
   setCurrentFilter(status);
 
-  // Update active button
+  // Update active button state
   document.querySelectorAll('.status-filter button').forEach(btn => {
     const btnStatus = btn.dataset.status || 'all';
     btn.classList.toggle('active', btnStatus === status);


### PR DESCRIPTION
## Summary
- tweak filterPoints comment and leave active class update logic in place
- expand test coverage for filterPoints button states

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_685697064920832cb7c6b564f85d40e3