### PR TITLE
MP-7: assert showToast messages on parse errors

### DIFF
--- a/public/js/tests/file-io.test.js
+++ b/public/js/tests/file-io.test.js
@@ -2,7 +2,7 @@ import { importFromCSV, importFromGeoJSON } from '../file-io.js';
 import { showToast } from '../ui-handlers.js';
 
 jest.mock('../ui-handlers.js', () => ({
-  showToast: jest.fn()
+  showToast: jest.fn(),
 }));
 
 describe('File IO error handling', () => {
@@ -14,20 +14,20 @@ describe('File IO error handling', () => {
     global.Papa = {
       parse: (_file, options) => {
         options.complete({ data: [], errors: [{ message: 'bad' }] });
-      }
+      },
     };
 
     const file = new File(['name,lat,lng\n'], 'points.csv', { type: 'text/csv' });
     importFromCSV(file);
-    expect(showToast).toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith(expect.stringContaining('Error importing CSV'));
   });
 
-  it('calls showToast when GeoJSON parsing fails', (done) => {
+  it('calls showToast when GeoJSON parsing fails', done => {
     const blob = new Blob(['invalid'], { type: 'application/json' });
     const file = new File([blob], 'points.geojson', { type: 'application/json' });
     importFromGeoJSON(file);
     setTimeout(() => {
-      expect(showToast).toHaveBeenCalled();
+      expect(showToast).toHaveBeenCalledWith(expect.stringContaining('Error importing GeoJSON'));
       done();
     }, 0);
   });


### PR DESCRIPTION
## Summary
- check `showToast` message content in CSV/GeoJSON parse error tests

## Testing
- `pnpm test`
- `pnpm lint` *(fails: dataProcessing.ts unused vars)*

------
https://chatgpt.com/codex/tasks/task_b_6856970a4980832c990737cd8c4f36a1