### PR TITLE
Replace imports in main.js

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -6,13 +6,12 @@ import {
   toggleStatistics,
   showGroupFilter,
   closeGroupFilter,
-  applyGroupFilter,
-  toggleAdvancedSearch,
   toggleBulkEdit,
   applyBulkEdit
 } from './modals.js';
 import { initUIHandlers, showToast, updatePointsList, updateStatistics } from './ui-handlers.js';
 import { exportToGeoJSON, importFromGeoJSON, exportToJSON, importFromJSON } from './file-io.js';
+import { points, addPoint, removePoint } from './state.js';
 import { store } from './store.js';
 
 let map;


### PR DESCRIPTION
## Summary
- streamline the import block at the top of `public/js/main.js`

## Testing
- `pnpm lint` *(fails: ban-ts-comment, unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6856977a07d0832cb41b9d6b584468a2