### PR TITLE
Fix satellite layer initialization

### DIFF
--- a/public/js/map-init.js
+++ b/public/js/map-init.js
@@ -9,20 +9,26 @@ export function initMap() {
   map = L.map('map').setView([0, 0], 2);
 
   // Add base layers
-  const osmLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: '© OpenStreetMap contributors',
-  });
+  const osmLayer = L.tileLayer(
+    'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    {
+      attribution: '© OpenStreetMap contributors',
+    }
+  );
 
-  import L from 'leaflet';
+  const satelliteLayer = L.tileLayer(
     'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
     {
       attribution: '© Esri',
     }
   );
 
-  const terrainLayer = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
-    attribution: '© OpenStreetMap contributors',
-  });
+  const terrainLayer = L.tileLayer(
+    'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
+    {
+      attribution: '© OpenStreetMap contributors',
+    }
+  );
 
   // Add default layer
   osmLayer.addTo(map);


### PR DESCRIPTION
## Summary
- clean up satellite layer creation

## Testing
- `node --check public/js/map-init.js`
- `pnpm lint` *(fails: '@ts-expect-error' vs '@ts-ignore', etc.)*
- `pnpm test` *(fails: TS5102 suppressImplicitAnyIndexErrors removed)*

------
https://chatgpt.com/codex/tasks/task_b_68569a82b800832c96d8f5561eacf963