### PR TITLE
Add error handling tests for import/export

### DIFF
--- a/src/__tests__/DataExport.test.tsx
+++ b/src/__tests__/DataExport.test.tsx
@@ -62,4 +62,23 @@ describe('DataExport CSV export', () => {
       global.URL.revokeObjectURL = originalRevokeObjectURL;
     }
   });
+
+  it('calls onExportError when export fails', () => {
+    const error = new Error('fail');
+    const points: MapPoint[] = [{ id: '1', position: { lat: 0, lng: 0 }, properties: {} }];
+    const onExportError = jest.fn();
+
+    const originalBlob = global.Blob;
+    // @ts-ignore - override for test
+    global.Blob = jest.fn(() => {
+      throw error;
+    }) as unknown as typeof Blob;
+
+    const { getByTitle } = render(<DataExport points={points} onExportError={onExportError} />);
+    fireEvent.click(getByTitle('Export as CSV'));
+
+    expect(onExportError).toHaveBeenCalledWith(error);
+
+    global.Blob = originalBlob;
+  });
 });

--- a/src/__tests__/DataImport.test.tsx
+++ b/src/__tests__/DataImport.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { DataImport } from '../components/controls/data-import';
 
@@ -25,5 +25,60 @@ describe('DataImport warnings display', () => {
 
     const { getByText } = render(<DataImport />);
     expect(getByText('Sample warning')).toBeInTheDocument();
+  });
+});
+
+describe('DataImport error handling', () => {
+  it('calls onError when CSV processing returns errors', async () => {
+    const mockProcessCSV = jest.fn().mockResolvedValue({
+      data: [],
+      warnings: [],
+      errors: [{ message: 'bad csv', code: 'CSV_ERROR' }],
+    });
+    mockedUseDataProcessing.mockReturnValue({
+      processCSV: mockProcessCSV,
+      processGeoJSON: jest.fn(),
+      addPoint: jest.fn(),
+      updatePoint: jest.fn(),
+      deletePoint: jest.fn(),
+      points: [],
+      errors: [],
+      warnings: [],
+      isLoading: false,
+    });
+
+    const onError = jest.fn();
+    const { getByLabelText } = render(<DataImport onError={onError} />);
+    const input = getByLabelText(/drop your file/i) as HTMLInputElement;
+    const file = new File(['id,name\n1,a'], 'points.csv', { type: 'text/csv' });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'bad csv' }));
+    });
+  });
+
+  it('calls onError for unsupported file types', async () => {
+    mockedUseDataProcessing.mockReturnValue({
+      processCSV: jest.fn(),
+      processGeoJSON: jest.fn(),
+      addPoint: jest.fn(),
+      updatePoint: jest.fn(),
+      deletePoint: jest.fn(),
+      points: [],
+      errors: [],
+      warnings: [],
+      isLoading: false,
+    });
+
+    const onError = jest.fn();
+    const { getByLabelText } = render(<DataImport onError={onError} />);
+    const input = getByLabelText(/drop your file/i) as HTMLInputElement;
+    const file = new File(['test'], 'data.txt', { type: 'text/plain' });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- expand `DataImport.test.tsx` to cover error paths
- add failure path test to `DataExport.test.tsx`
- ensure TypeScript tests compile and pass

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_68569ac897d8832c82c115e689cdb9bf