### PR TITLE
Fix build output generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ pnpm build
 pnpm start
 ```
 
+The compiled JavaScript will be written to `public/build`.
+
 ## 🧪 Running Tests
 
 Run the test suite with:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true,
+    "noEmit": false,
     "noImplicitAny": false
   },
   "include": [


### PR DESCRIPTION
## Summary
- allow TypeScript to emit compiled files
- document build output location

## Testing
- `pnpm lint` *(fails: component definition missing display name, merge conflict markers, etc.)*
- `pnpm test` *(fails: Option 'suppressImplicitAnyIndexErrors' has been removed)*

------
https://chatgpt.com/codex/tasks/task_b_6856a24417e4832c9cdc146426dff148