### PR TITLE
Add DATA_STORE env option for DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ FIREBASE_PROJECT_ID=your-project-id
 FIREBASE_STORAGE_BUCKET=your-project-id.appspot.com
 FIREBASE_APP_ID=your-firebase-app-id
 PORT=3000 # override default port
+DATA_STORE=file # use the file-based data store
 ```
 
 These variables are loaded at runtime if present.

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,7 +1,9 @@
 import memoryStore from './memory-store';
+import fileStore from './file-store';
 export type { DataStore } from './data-store';
 
-// In the future this could switch based on config
-export const dataStore = memoryStore;
+// Select data store based on environment
+export const dataStore =
+  process.env.DATA_STORE === 'file' ? fileStore : memoryStore;
 
 export default dataStore;


### PR DESCRIPTION
## Summary
- choose between memory or file stores via `DATA_STORE` env var
- document `DATA_STORE` in README

## Testing
- `pnpm lint` *(fails: 20 problems)*
- `pnpm test` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_b_6856a2452fcc832c891df43180070218