### PR TITLE
Fix auto merge action

### DIFF
--- a/.github/workflows/auto-merge-codex-prs.yml
+++ b/.github/workflows/auto-merge-codex-prs.yml
@@ -32,4 +32,6 @@ jobs:
         if: steps.mergeable.outputs.mergeable == 'true'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
+          pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash
+

--- a/github_workflows_enable-auto-merge_Version2.yml
+++ b/github_workflows_enable-auto-merge_Version2.yml
@@ -22,5 +22,5 @@ jobs:
 
       - uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          # Example configuration (customize as needed)
-          # merge-method: squash
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash


### PR DESCRIPTION
## Summary
- fix workflow to specify PR number when enabling auto-merge

## Testing
- `pnpm biome format .` *(fails: command not found)*
- `pnpm biome check .` *(fails: command not found)*
- `pnpm typecheck` *(fails: script missing)*
- `pnpm lint` *(fails: 2 errors)*
- `pnpm test` *(fails: ts-jest config option removed)*

------
https://chatgpt.com/codex/tasks/task_b_68570c8bd1a0832ca5b41a15ecd0245d