### PR TITLE
MP-6 adjust tests and component display names

### DIFF
--- a/src/__tests__/DataExport.test.tsx
+++ b/src/__tests__/DataExport.test.tsx
@@ -38,11 +38,8 @@ describe('DataExport CSV export', () => {
       const createObjectURL = jest.fn(() => 'blob:url');
       const revokeObjectURL = jest.fn();
 
-      // @ts-expect-error: MockBlob used for testing
       global.Blob = MockBlob as unknown as typeof Blob;
-      // @ts-expect-error override for readonly property during test
       global.URL.createObjectURL = createObjectURL;
-      // @ts-expect-error revokeObjectURL mocked for test
       global.URL.revokeObjectURL = revokeObjectURL;
 
       const { getByTitle } = render(<DataExport points={points} />);
@@ -56,9 +53,7 @@ describe('DataExport CSV export', () => {
       expect(dataRow).toBe('1,10,20,0,false');
     } finally {
       global.Blob = originalBlob;
-      // @ts-expect-error restore original after test
       global.URL.createObjectURL = originalCreateObjectURL;
-      // @ts-expect-error restore original after test
       global.URL.revokeObjectURL = originalRevokeObjectURL;
     }
   });

--- a/src/__tests__/DataTable.test.tsx
+++ b/src/__tests__/DataTable.test.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
+import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { DataTable } from '../components/controls/data-table';
 import { MapPoint } from '../types/map.types';
 
 jest.mock('react-window', () => {
-  const React = require('react');
   return {
     FixedSizeList: ({
       height,

--- a/src/__tests__/MapComponent.test.tsx
+++ b/src/__tests__/MapComponent.test.tsx
@@ -15,16 +15,16 @@ const mockMap = {
 };
 
 jest.mock('react-leaflet', () => {
-  const MockMapContainer = React.forwardRef<any, any>((props, ref) => {
+  const MockMapContainer = React.forwardRef<HTMLDivElement, React.PropsWithChildren>((props, ref) => {
     React.useImperativeHandle(ref, () => mockMap, []);
     return React.createElement('div', null, props.children);
   });
   MockMapContainer.displayName = 'MapContainer';
   return {
     MapContainer: MockMapContainer,
-    TileLayer: (props: unknown) => React.createElement('div', null, props.children),
-    Marker: (props: unknown) => React.createElement('div', null, props.children),
-    Popup: (props: unknown) => React.createElement('div', null, props.children),
+    TileLayer: (props: React.PropsWithChildren<unknown>) => React.createElement('div', null, props.children),
+    Marker: (props: React.PropsWithChildren<unknown>) => React.createElement('div', null, props.children),
+    Popup: (props: React.PropsWithChildren<unknown>) => React.createElement('div', null, props.children),
   };
 });
 

--- a/src/components/controls/data-table.tsx
+++ b/src/components/controls/data-table.tsx
@@ -174,3 +174,5 @@ export const DataTable: React.FC<DataTableProps> = ({
     </div>
   );
 };
+
+DataTable.displayName = 'DataTable';


### PR DESCRIPTION
## Summary
- swap `require('react')` with ES import
- expose `DataTable.displayName`
- clean up `@ts-expect-error` comments in DataExport tests
- type children props for mock components

## Testing
- `pnpm lint` *(fails: Unexpected console statement)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_68570c808408832c95b160351679526a