### PR TITLE
Add offline sync via indexed DB and service worker

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -50,3 +50,19 @@ self.addEventListener('fetch', e => {
     })
   );
 });
+
+self.addEventListener('message', event => {
+  if (event.data === 'queue-edit' && 'sync' in self.registration) {
+    self.registration.sync.register('sync-edits').catch(() => {});
+  }
+});
+
+self.addEventListener('sync', event => {
+  if (event.tag === 'sync-edits') {
+    event.waitUntil(
+      self.clients.matchAll().then(clients => {
+        clients.forEach(client => client.postMessage({ type: 'sync-edits' }));
+      })
+    );
+  }
+});

--- a/src/hooks/useOfflineSync.ts
+++ b/src/hooks/useOfflineSync.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+import { MapPoint } from '../types';
+import {
+  getQueuedOperations,
+  clearQueuedOperations,
+  OfflineOperation,
+} from '../services/storage/indexed-db';
+
+async function pushOperations(ops: OfflineOperation[]): Promise<void> {
+  await Promise.all(
+    ops.map(op => {
+      if (op.type === 'update') {
+        const point = op.payload as MapPoint;
+        return fetch(`/api/maps/${point.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(point),
+        });
+      }
+      return fetch(`/api/maps/${(op.payload as { id: string }).id}`, {
+        method: 'DELETE',
+      });
+    })
+  );
+}
+
+export const useOfflineSync = (): void => {
+  useEffect(() => {
+    const sync = async (): Promise<void> => {
+      const ops = await getQueuedOperations();
+      if (ops.length === 0) return;
+      try {
+        await pushOperations(ops);
+        await clearQueuedOperations();
+      } catch (err) {
+        console.error('Failed to sync offline operations', err);
+      }
+    };
+
+    window.addEventListener('online', sync);
+    return () => {
+      window.removeEventListener('online', sync);
+    };
+  }, []);
+};
+
+export default useOfflineSync;

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -13,4 +13,4 @@ router.get('/health', (req, res) => {
 router.use('/maps', mapRoutes);
 router.use('/users', userRoutes);
 
-export default router; 
+export default router;

--- a/src/services/storage/indexed-db.ts
+++ b/src/services/storage/indexed-db.ts
@@ -1,0 +1,64 @@
+export interface OfflineOperation {
+  id: string;
+  type: 'update' | 'delete';
+  payload: Record<string, unknown>;
+  timestamp: number;
+}
+
+const DB_NAME = 'maptap';
+const STORE_NAME = 'operations';
+const VERSION = 1;
+
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function queueOperation(operation: OfflineOperation): Promise<void> {
+  const db = await openDatabase();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  tx.objectStore(STORE_NAME).put(operation);
+  if (navigator.serviceWorker && navigator.serviceWorker.controller) {
+    navigator.serviceWorker.controller.postMessage('queue-edit');
+  }
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function getQueuedOperations(): Promise<OfflineOperation[]> {
+  const db = await openDatabase();
+  const tx = db.transaction(STORE_NAME, 'readonly');
+  const store = tx.objectStore(STORE_NAME);
+  const request = store.getAll();
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result as OfflineOperation[]);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function clearQueuedOperations(): Promise<void> {
+  const db = await openDatabase();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  tx.objectStore(STORE_NAME).clear();
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export default {
+  queueOperation,
+  getQueuedOperations,
+  clearQueuedOperations,
+};


### PR DESCRIPTION
## Summary
- store offline edits in IndexedDB via `indexed-db.ts`
- sync queued edits when online with `useOfflineSync`
- trigger Background Sync through `service-worker.js`
- fix stray text in `src/routes/api.ts`

## Testing
- `pnpm lint` *(fails: 2 errors)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_68570c7f6798832c900405e09eec785a