### PR TITLE
MP-1: integrate performance monitor into store (#115)

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -11,7 +11,6 @@ import {
 } from './modals.js';
 import { initUIHandlers, showToast, updatePointsList, updateStatistics } from './ui-handlers.js';
 import { exportToGeoJSON, importFromGeoJSON, exportToJSON, importFromJSON } from './file-io.js';
-import { points, addPoint, removePoint } from './state.js';
 import { store } from './store.js';
 
 let map;

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -1,8 +1,0 @@
-import { store } from './store.js';
-import { PerformanceMonitor } from './utils.js';
-
-/**
- * Single instance used across modules for performance measurements.
- * Other state is now managed via store.js
- */
-export const performanceMonitor = new PerformanceMonitor();

--- a/public/js/store.js
+++ b/public/js/store.js
@@ -1,4 +1,4 @@
-import { Pagination, UndoRedoManager } from './utils.js';
+import { Pagination, UndoRedoManager, PerformanceMonitor } from './utils.js';
 
 /** @type {import('./types').MapPoint[]} */
 let points = [];
@@ -6,6 +6,9 @@ let currentFilter = 'all';
 let currentGroupFilter = null;
 const pagination = new Pagination([]);
 const undoRedoManager = new UndoRedoManager();
+
+/** @type {PerformanceMonitor} */
+export const performanceMonitor = new PerformanceMonitor();
 
 let isAddingPoint = false;
 let currentLatLng = null;
@@ -55,6 +58,7 @@ export const store = {
   },
   pagination,
   undoRedoManager,
+  performanceMonitor,
   get isAddingPoint() {
     return isAddingPoint;
   },

--- a/public/js/tests/store.test.js
+++ b/public/js/tests/store.test.js
@@ -1,0 +1,12 @@
+import { store, performanceMonitor } from '../store.js';
+
+describe('store module', () => {
+  test('performanceMonitor is exported', () => {
+    expect(performanceMonitor).toBeDefined();
+    expect(typeof performanceMonitor.start).toBe('function');
+  });
+
+  test('store exposes performanceMonitor instance', () => {
+    expect(store.performanceMonitor).toBeDefined();
+  });
+});

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -1,7 +1,6 @@
 import { addMarker } from './map-init.js';
 import { debounce, sanitizeInput, Validator } from './utils.js';
-import { store } from './store.js';
-import { performanceMonitor } from './state.js';
+import { store, performanceMonitor } from './store.js';
 
 // Initialize UI handlers
 export function initUIHandlers() {


### PR DESCRIPTION
## Summary
- inline `performanceMonitor` in the store module
- update imports in `ui-handlers.js` and `main.js`
- drop now unused `state.js`
- add a small test for the new export

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_6857a1daf1c0832caee688ca53706761