### PR TITLE
Fix performance monitor duplicate

### DIFF
--- a/public/js/store.js
+++ b/public/js/store.js
@@ -12,7 +12,6 @@ export const performanceMonitor = new PerformanceMonitor();
 
 let isAddingPoint = false;
 let currentLatLng = null;
-// const performanceMonitor = new PerformanceMonitor(); // remove this line
 
 // expose globals for legacy usage
 Object.defineProperty(window, 'isAddingPoint', {
@@ -60,7 +59,6 @@ export const store = {
   pagination,
   performanceMonitor,
   undoRedoManager,
-  performanceMonitor,
   get isAddingPoint() {
     return isAddingPoint;
   },


### PR DESCRIPTION
## Summary
- remove leftover comment and duplicate performance monitor export

## Testing
- `pnpm lint`
- `pnpm exec jest "public/js/tests" --config '{"testMatch":["**/public/js/tests/**/*.test.js"],"transform":{}}'` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_6857d23a82e8832ca4e15474a6991d0a