### PR TITLE
Add clearMarkers helper and update map modules

### DIFF
--- a/public/js/file-io.js
+++ b/public/js/file-io.js
@@ -1,5 +1,5 @@
 // File import/export operations
-import { addMarker } from './map-init.js';
+import { addMarker, clearMarkers } from './map-init.js';
 import { showToast } from './ui-handlers.js';
 import { store } from './store.js';
 
@@ -267,7 +267,7 @@ export function importFromJSON(file) {
       localStorage.setItem('mapPoints', JSON.stringify(store.points));
 
       // Update UI
-      markers.clearLayers();
+      clearMarkers();
       store.points.forEach(point => addMarker(point.latlng, point));
       updatePointsList();
       updateStatistics();

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,5 +1,5 @@
 // Main application entry point
-import { initMap, toggleLayer, addMarker } from './map-init.js';
+import { initMap, toggleLayer, addMarker, clearMarkers } from './map-init.js';
 import {
   togglePointsList,
   toggleLayerControls,
@@ -115,7 +115,7 @@ function clearAllData() {
     while (store.points.length) {
       store.removePoint(store.points[0].id);
     }
-    markers && markers.clearLayers();
+    clearMarkers();
     updatePointsList();
     updateStatistics();
     showToast('All data cleared');

--- a/public/js/map-init.js
+++ b/public/js/map-init.js
@@ -78,6 +78,10 @@ export function addMarker(latlng, data) {
   return marker;
 }
 
+export function clearMarkers() {
+  markers.clearLayers();
+}
+
 // Create custom icon based on status
 function createCustomIcon(status) {
   return L.divIcon({

--- a/public/js/tests/file-io.test.js
+++ b/public/js/tests/file-io.test.js
@@ -4,6 +4,10 @@ import { showToast } from '../ui-handlers.js';
 jest.mock('../ui-handlers.js', () => ({
   showToast: jest.fn(),
 }));
+jest.mock('../map-init.js', () => ({
+  addMarker: jest.fn(),
+  clearMarkers: jest.fn(),
+}));
 
 describe('File IO error handling', () => {
   beforeEach(() => {

--- a/public/js/tests/ui-handlers.test.js
+++ b/public/js/tests/ui-handlers.test.js
@@ -31,6 +31,7 @@ document.body.innerHTML = `
 // Mock map functions
 jest.mock('../map-init.js', () => ({
   addMarker: jest.fn(),
+  clearMarkers: jest.fn(),
 }));
 
 describe('UI Handlers', () => {

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -1,4 +1,4 @@
-import { addMarker } from './map-init.js';
+import { addMarker, clearMarkers } from './map-init.js';
 import { debounce, sanitizeInput, Validator } from './utils.js';
 import { store } from './store.js';
 const { performanceMonitor } = store;
@@ -298,7 +298,7 @@ export function filterPoints(status) {
   });
 
   // Filter markers
-  markers.clearLayers();
+  clearMarkers();
   store.points
     .filter(point => {
       if (status === 'all') return true;
@@ -378,7 +378,7 @@ async function savePoint(pointData) {
     localStorage.setItem('mapPoints', JSON.stringify(store.points));
 
     // Update map
-    markers.clearLayers();
+    clearMarkers();
     store.points.forEach(point => addMarker(point.latlng, point));
 
     return true;
@@ -422,7 +422,7 @@ export function deletePoint(pointId) {
       localStorage.setItem('mapPoints', JSON.stringify(store.points));
 
       // Update UI
-      markers.clearLayers();
+      clearMarkers();
       store.points.forEach(point => addMarker(point.latlng, point));
       updatePointsList();
       updateStatistics();


### PR DESCRIPTION
## Summary
- expose `clearMarkers` from `map-init.js`
- replace direct `markers.clearLayers()` calls with `clearMarkers`
- mock `clearMarkers` in file IO and UI handler tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_6857d23e2068832c802c48d7c6820f8b