### PR TITLE
Update file IO helpers and tests

### DIFF
--- a/public/js/file-io.js
+++ b/public/js/file-io.js
@@ -1,6 +1,6 @@
 // File import/export operations
-import { addMarker } from './map-init.js';
-import { showToast } from './ui-handlers.js';
+import { addMarker, clearMarkers } from './map-init.js';
+import { showToast, updatePointsList, updateStatistics } from './ui-handlers.js';
 import { store } from './store.js';
 
 // Export points to CSV
@@ -267,7 +267,7 @@ export function importFromJSON(file) {
       localStorage.setItem('mapPoints', JSON.stringify(store.points));
 
       // Update UI
-      markers.clearLayers();
+      clearMarkers();
       store.points.forEach(point => addMarker(point.latlng, point));
       updatePointsList();
       updateStatistics();

--- a/public/js/map-init.js
+++ b/public/js/map-init.js
@@ -120,6 +120,6 @@ export function toggleCluster() {
   }
 }
 
-export function clearMarkers() {
+export function clearAllMarkers() {
   markers.clearLayers();
 }

--- a/public/js/map-init.js
+++ b/public/js/map-init.js
@@ -115,3 +115,7 @@ export function toggleCluster() {
     }
   }
 }
+
+export function clearMarkers() {
+  markers.clearLayers();
+}

--- a/public/js/tests/file-io.test.js
+++ b/public/js/tests/file-io.test.js
@@ -1,8 +1,17 @@
 import { importFromCSV, importFromGeoJSON, importFromJSON } from '../file-io.js';
-import { showToast } from '../ui-handlers.js';
+import { showToast, updatePointsList, updateStatistics } from '../ui-handlers.js';
+import { clearMarkers } from '../map-init.js';
+import { store } from '../store.js';
 
 jest.mock('../ui-handlers.js', () => ({
   showToast: jest.fn(),
+  updatePointsList: jest.fn(),
+  updateStatistics: jest.fn(),
+}));
+
+jest.mock('../map-init.js', () => ({
+  addMarker: jest.fn(),
+  clearMarkers: jest.fn(),
 }));
 
 describe('File IO error handling', () => {
@@ -40,5 +49,61 @@ describe('File IO error handling', () => {
       expect(showToast).toHaveBeenCalled();
       done();
     }, 0);
+  });
+});
+
+describe('File IO success updates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.L = { latLng: (lat, lng) => ({ lat, lng }) };
+    store.points = [];
+  });
+
+  it('invokes UI updates on CSV import confirm', () => {
+    document.body.innerHTML = `
+      <div id="csvPreviewModal"></div>
+      <div id="csvPreviewTable"></div>
+      <select id="latField"></select>
+      <select id="lngField"></select>
+      <select id="labelField"></select>
+      <button id="confirmCsvImportBtn"></button>
+    `;
+
+    global.Papa = {
+      parse: (_file, options) => {
+        options.complete({
+          data: [{ latitude: '1', longitude: '2', name: 'test' }],
+          errors: [],
+        });
+      },
+    };
+
+    const file = new File(['latitude,longitude,name\n1,2,test'], 'points.csv', { type: 'text/csv' });
+    importFromCSV(file);
+
+    document.getElementById('latField').value = 'latitude';
+    document.getElementById('lngField').value = 'longitude';
+    document.getElementById('labelField').value = 'name';
+
+    document.getElementById('confirmCsvImportBtn').onclick();
+
+    expect(updatePointsList).toHaveBeenCalled();
+    expect(updateStatistics).toHaveBeenCalled();
+  });
+
+  it('invokes UI updates on JSON import', () => {
+    global.FileReader = class {
+      readAsText() {
+        this.onload({ target: { result: JSON.stringify([{ id: '1', latlng: { lat: 0, lng: 0 } }]) } });
+      }
+    };
+
+    const blob = new Blob(['[]'], { type: 'application/json' });
+    const file = new File([blob], 'points.json', { type: 'application/json' });
+    importFromJSON(file);
+
+    expect(clearMarkers).toHaveBeenCalled();
+    expect(updatePointsList).toHaveBeenCalled();
+    expect(updateStatistics).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add `clearMarkers` export to map-init
- use `clearMarkers`, `updatePointsList`, `updateStatistics` in file-io
- mock new helpers in file-io tests and verify UI updates on import

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_6857d23c6e58832cae1899f083c0a289