### PR TITLE
Fix module imports in modals

### DIFF
--- a/public/js/modals.js
+++ b/public/js/modals.js
@@ -1,7 +1,13 @@
 // Modal dialog management
-import { showToast } from './ui-handlers.js';
+import {
+  showToast,
+  filterPoints,
+  updatePointsList,
+  updateStatistics,
+} from './ui-handlers.js';
 import { store } from './store.js';
 import { trapFocus } from './utils.js';
+import { addMarker, clearMarkers } from './map-init.js';
 
 // Toggle modal visibility
 export function toggleModal(modalId, show = true) {
@@ -102,7 +108,7 @@ export function applyAdvancedSearch() {
   });
 
   // Update markers
-  markers.clearLayers();
+  clearMarkers();
   filteredPoints.forEach(point => addMarker(point.latlng, point));
 
   toggleAdvancedSearch();

--- a/public/js/tests/modals.test.js
+++ b/public/js/tests/modals.test.js
@@ -1,10 +1,16 @@
+jest.mock('../ui-handlers.js', () => ({
+  filterPoints: jest.fn(),
+  updatePointsList: jest.fn(),
+  updateStatistics: jest.fn(),
+  showToast: jest.fn(),
+}));
+jest.mock('../map-init.js', () => ({
+  addMarker: jest.fn(),
+  clearMarkers: jest.fn(),
+}));
+
 import { applyBulkEdit } from '../modals.js';
 import { store } from '../store.js';
-
-// Set up global functions used by applyBulkEdit
-global.filterPoints = jest.fn();
-global.updatePointsList = jest.fn();
-global.updateStatistics = jest.fn();
 
 describe('applyBulkEdit', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- import filter and update helpers in `modals.js`
- switch to `clearMarkers` helper
- mock helper modules in `modals.test`

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_6857d48e1dc8832c927740e64ac24dcf