### PR TITLE
Expose point actions globally

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -9,7 +9,15 @@ import {
   toggleBulkEdit,
   applyBulkEdit
 } from './modals.js';
-import { initUIHandlers, showToast, updatePointsList, updateStatistics } from './ui-handlers.js';
+import {
+  initUIHandlers,
+  showToast,
+  updatePointsList,
+  updateStatistics,
+  editPoint,
+  deletePoint,
+  togglePointSelection,
+} from './ui-handlers.js';
 import {
   exportToGeoJSON,
   importFromGeoJSON,
@@ -18,6 +26,11 @@ import {
   importFromCSV,
 } from './file-io.js';
 import { store } from './store.js';
+
+// Expose selected UI handlers globally for legacy inline handlers
+window.editPoint = editPoint;
+window.deletePoint = deletePoint;
+window.togglePointSelection = togglePointSelection;
 
 let map;
 

--- a/public/js/tests/main.test.js
+++ b/public/js/tests/main.test.js
@@ -1,0 +1,9 @@
+import '../main.js';
+
+describe('main globals', () => {
+  it('exposes UI handlers on window', () => {
+    expect(window.editPoint).toBeDefined();
+    expect(window.deletePoint).toBeDefined();
+    expect(window.togglePointSelection).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- expose `editPoint`, `deletePoint`, and `togglePointSelection` from `ui-handlers` in the main script
- provide global access for these functions
- add Jest test verifying the globals

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_6857d92df408832cb0ecfe5de80bc0b1