### PR TITLE
Add updateMapMarkers helper with tests

### DIFF
--- a/public/js/tests/ui-handlers.test.js
+++ b/public/js/tests/ui-handlers.test.js
@@ -5,8 +5,9 @@ import {
   hidePointForm,
   filterPoints,
   togglePointSelection,
+  updateMapMarkers,
 } from '../ui-handlers.js';
-import { addMarker } from '../map-init.js';
+import { addMarker, clearMarkers } from '../map-init.js';
 import { toggleModal } from '../modals.js';
 import { store } from '../store.js';
 
@@ -217,6 +218,22 @@ describe('UI Handlers', () => {
 
       toggleModal('testModal', false);
       expect(document.activeElement).toBe(beforeBtn);
+    });
+  });
+
+  describe('updateMapMarkers', () => {
+    it('clears existing markers and adds markers for all points', () => {
+      store.points = [
+        { id: '1', latlng: { lat: 0, lng: 0 } },
+        { id: '2', latlng: { lat: 1, lng: 1 } },
+      ];
+
+      updateMapMarkers();
+
+      expect(clearMarkers).toHaveBeenCalled();
+      expect(addMarker).toHaveBeenCalledTimes(2);
+      expect(addMarker).toHaveBeenCalledWith({ lat: 0, lng: 0 }, store.points[0]);
+      expect(addMarker).toHaveBeenCalledWith({ lat: 1, lng: 1 }, store.points[1]);
     });
   });
 });

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -193,6 +193,12 @@ function sortPoints(sortBy) {
   }
 }
 
+// Refresh map markers based on current points
+export function updateMapMarkers() {
+  clearMarkers();
+  store.points.forEach(p => addMarker(p.latlng, p));
+}
+
 // Update UI elements with performance monitoring
 function updateUI() {
   performanceMonitor.start('updateUI');


### PR DESCRIPTION
## Summary
- define `updateMapMarkers` to refresh markers
- export helper and test its behavior

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Option 'suppressImplicitAnyIndexErrors' has been removed)*

------
https://chatgpt.com/codex/tasks/task_b_6857e14f7870832c87dc65f006021f06