### PR TITLE
MP-9: normalize map component folder and enforce exports

### DIFF
--- a/src/components/map/draggable-marker.tsx
+++ b/src/components/map/draggable-marker.tsx
@@ -1,9 +1,9 @@
-// src/components/Map/DraggableMarker.tsx
+// src/components/map/draggable-marker.tsx
 // MP-0: fix: remove unused imports and update ts-ignore
 
 import React from 'react';
 import { Marker } from 'react-leaflet';
-import { LatLngExpression } from 'leaflet';
+import L, { LatLngExpression } from 'leaflet';
 
 interface DraggableMarkerProps {
   position: LatLngExpression;
@@ -11,12 +11,8 @@ interface DraggableMarkerProps {
   children?: React.ReactNode;
 }
 
-const DraggableMarker: React.FC<DraggableMarkerProps> = ({ 
-  position, 
-  onDragEnd, 
-  children 
-}) => {
-  const markerRef = React.useRef<any>(null);
+const DraggableMarker: React.FC<DraggableMarkerProps> = ({ position, onDragEnd, children }) => {
+  const markerRef = React.useRef<L.Marker | null>(null);
 
   const eventHandlers = React.useMemo(
     () => ({
@@ -32,12 +28,7 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
   );
 
   return (
-    <Marker
-      draggable={true}
-      eventHandlers={eventHandlers}
-      position={position}
-      ref={markerRef}
-    >
+    <Marker draggable={true} eventHandlers={eventHandlers} position={position} ref={markerRef}>
       {children}
     </Marker>
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ dotenv.config();
 
 const __dirname = path.dirname(__filename);
 
-const app = express();
+export const app = express();
 const port = process.env.PORT || 3000;
 
 // Security middleware

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -11,3 +11,5 @@ if (typeof Blob !== 'undefined' && !Blob.prototype.text) {
     });
   };
 }
+
+export {};


### PR DESCRIPTION
## Summary
- merge `Map` and `map` component folders into kebab-case `map`
- add missing exports to `server.ts` and `setupTests.ts`
- replace `any` in `draggable-marker` ref with proper Leaflet marker type

## Testing
- `pnpm lint src/components/map/draggable-marker.tsx src/server.ts src/setupTests.ts` *(fails: unused vars etc. in unrelated files)*
- `pnpm test` *(fails: multiple failing suites)*
- `pnpm build` *(fails: type errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_b_68c21220cf8c832ca78ead0dfe2decf6