### PR TITLE
MP-7: add field reordering and field search

### DIFF
--- a/src/__tests__/DataTable.test.tsx
+++ b/src/__tests__/DataTable.test.tsx
@@ -56,7 +56,7 @@ describe('DataTable sorting', () => {
 });
 
 describe('DataTable virtualization', () => {
-  const points = Array.from({ length: 20 }, (_, i) => 
+  const points = Array.from({ length: 20 }, (_, i) =>
     createMapPoint({ id: String(i + 1), position: { lat: 0, lng: 0 }, properties: {} })
   );
 
@@ -64,5 +64,52 @@ describe('DataTable virtualization', () => {
     const { getAllByRole } = render(<DataTable points={points} />);
     const rows = getAllByRole('row');
     expect(rows).toHaveLength(11); // 10 visible + header
+  });
+});
+
+describe('DataTable field utilities', () => {
+  const points = [
+    createMapPoint({
+      id: '1',
+      position: { lat: 0, lng: 0 },
+      properties: { name: 'Alpha', type: 'A' },
+    }),
+  ];
+
+  it('filters columns based on field search', () => {
+    const { getByPlaceholderText, queryByText, getByText } = render(<DataTable points={points} />);
+    expect(getByText('name')).toBeInTheDocument();
+    expect(getByText('type')).toBeInTheDocument();
+    const fieldInput = getByPlaceholderText('Search fields...');
+    fireEvent.change(fieldInput, { target: { value: 'name' } });
+    expect(getByText('name')).toBeInTheDocument();
+    expect(queryByText('type')).not.toBeInTheDocument();
+  });
+
+  it('reorders columns via drag and drop', () => {
+    const { getByText, getAllByRole } = render(<DataTable points={points} />);
+    const typeHeader = getByText('type');
+    const nameHeader = getByText('name');
+    const dataTransfer = {
+      data: {} as Record<string, string>,
+      setData(key: string, val: string) {
+        this.data[key] = val;
+      },
+      getData(key: string) {
+        return this.data[key];
+      },
+      effectAllowed: 'all',
+      dropEffect: 'move',
+      files: [],
+      items: [],
+      types: [],
+    } as unknown as DataTransfer;
+    fireEvent.dragStart(typeHeader, { dataTransfer });
+    fireEvent.dragOver(nameHeader, { dataTransfer });
+    fireEvent.drop(nameHeader, { dataTransfer });
+    const headers = getAllByRole('columnheader').map(h => h.textContent?.trim());
+    const typeIndex = headers.indexOf('type');
+    const nameIndex = headers.indexOf('name');
+    expect(typeIndex).toBeLessThan(nameIndex);
   });
 });

--- a/src/components/controls/data-table.tsx
+++ b/src/components/controls/data-table.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import { MapPoint } from '../../types/map.types';
 import styles from '../../styles/components/data-table.module.scss';
@@ -16,13 +16,11 @@ interface SortConfig {
   direction: SortDirection;
 }
 
-export const DataTable: React.FC<DataTableProps> = ({
-  points,
-  onPointSelect,
-  onPointDelete
-}) => {
+export const DataTable: React.FC<DataTableProps> = ({ points, onPointSelect, onPointDelete }) => {
   const [sortConfig, setSortConfig] = useState<SortConfig>({ key: 'id', direction: 'asc' });
   const [filterText, setFilterText] = useState('');
+  const [fieldOrder, setFieldOrder] = useState<string[]>([]);
+  const [fieldFilter, setFieldFilter] = useState('');
 
   const allProperties = useMemo(() => {
     const properties = new Set<string>();
@@ -39,9 +37,46 @@ export const DataTable: React.FC<DataTableProps> = ({
     }));
   }, []);
 
+  useEffect(() => {
+    setFieldOrder(allProperties);
+  }, [allProperties]);
+
   const handleFilter = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setFilterText(e.target.value.toLowerCase());
   }, []);
+
+  const handleFieldFilter = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setFieldFilter(e.target.value.toLowerCase());
+  }, []);
+
+  const handleDragStart = useCallback(
+    (e: React.DragEvent<HTMLTableHeaderCellElement>, index: number) => {
+      e.dataTransfer.setData('text/plain', String(index));
+    },
+    []
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLTableHeaderCellElement>, index: number) => {
+      const fromIndex = Number(e.dataTransfer.getData('text/plain'));
+      setFieldOrder(current => {
+        const updated = [...current];
+        const [moved] = updated.splice(fromIndex, 1);
+        updated.splice(index, 0, moved);
+        return updated;
+      });
+    },
+    []
+  );
+
+  const displayedFields = useMemo(() => {
+    const search = fieldFilter.toLowerCase();
+    return fieldOrder.filter(f => f.toLowerCase().includes(search));
+  }, [fieldOrder, fieldFilter]);
 
   const filteredAndSortedPoints = useMemo(() => {
     const filtered = points.filter(point => {
@@ -82,7 +117,8 @@ export const DataTable: React.FC<DataTableProps> = ({
     [onPointDelete]
   );
 
-  const Row = useCallback(function Row({ index, style }: ListChildComponentProps) {
+  const Row = useCallback(
+    function Row({ index, style }: ListChildComponentProps) {
       const point = filteredAndSortedPoints[index];
       return (
         <tr
@@ -94,7 +130,7 @@ export const DataTable: React.FC<DataTableProps> = ({
           <td>{point.id}</td>
           <td>{point.position.lat.toFixed(6)}</td>
           <td>{point.position.lng.toFixed(6)}</td>
-          {allProperties.map(property => (
+          {displayedFields.map(property => (
             <td key={property}>{point.properties[property] || '-'}</td>
           ))}
           <td>
@@ -109,10 +145,13 @@ export const DataTable: React.FC<DataTableProps> = ({
         </tr>
       );
     },
-    [filteredAndSortedPoints, handleRowClick, handleDelete, allProperties]
+    [filteredAndSortedPoints, handleRowClick, handleDelete, displayedFields]
   );
 
-  const OuterElement = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(function OuterElement(props, ref) {
+  const OuterElement = React.forwardRef<
+    HTMLTableSectionElement,
+    React.HTMLAttributes<HTMLTableSectionElement>
+  >(function OuterElement(props, ref) {
     return <tbody {...props} ref={ref as React.RefObject<HTMLTableSectionElement>} />;
   });
 
@@ -124,6 +163,13 @@ export const DataTable: React.FC<DataTableProps> = ({
           placeholder="Filter points..."
           value={filterText}
           onChange={handleFilter}
+          className={styles.filterInput}
+        />
+        <input
+          type="text"
+          placeholder="Search fields..."
+          value={fieldFilter}
+          onChange={handleFieldFilter}
           className={styles.filterInput}
         />
       </div>
@@ -142,16 +188,27 @@ export const DataTable: React.FC<DataTableProps> = ({
               </th>
               <th>Latitude</th>
               <th>Longitude</th>
-              {allProperties.map(property => (
-                <th key={property} onClick={() => handleSort(property)} className={styles.sortable}>
-                  {property}
-                  {sortConfig.key === property && (
-                    <span className={styles.sortIndicator}>
-                      {sortConfig.direction === 'asc' ? '↑' : '↓'}
-                    </span>
-                  )}
-                </th>
-              ))}
+              {displayedFields.map(property => {
+                const fieldIndex = fieldOrder.indexOf(property);
+                return (
+                  <th
+                    key={property}
+                    onClick={() => handleSort(property)}
+                    className={styles.sortable}
+                    draggable
+                    onDragStart={e => handleDragStart(e, fieldIndex)}
+                    onDragOver={handleDragOver}
+                    onDrop={e => handleDrop(e, fieldIndex)}
+                  >
+                    {property}
+                    {sortConfig.key === property && (
+                      <span className={styles.sortIndicator}>
+                        {sortConfig.direction === 'asc' ? '↑' : '↓'}
+                      </span>
+                    )}
+                  </th>
+                );
+              })}
               <th>Actions</th>
             </tr>
           </thead>


### PR DESCRIPTION
## Summary
- enable column drag-and-drop reordering in data table
- add field name search input to filter visible columns
- test column filtering and reordering behaviour

## Testing
- `pnpm biome format .` *(fails: Command "biome" not found)*
- `pnpm biome check .` *(fails: Command "biome" not found)*
- `pnpm lint` *(fails: 6 errors, 38 warnings)*
- `pnpm test` *(fails: 6 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c2123c7d78832cb877d3af67054efc